### PR TITLE
Purge database excuted before scenario

### DIFF
--- a/src/ApiTestCase.php
+++ b/src/ApiTestCase.php
@@ -78,10 +78,11 @@ abstract class ApiTestCase extends WebTestCase
     /**
      * @before
      */
-    public function setUpEntityManager()
+    public function setUpDatabase()
     {
         if (isset($_SERVER['IS_DOCTRINE_ORM_SUPPORTED']) && $_SERVER['IS_DOCTRINE_ORM_SUPPORTED']) {
             $this->entityManager = static::$sharedKernel->getContainer()->get('doctrine.orm.entity_manager');
+            $this->purgeDatabase();
         }
     }
 
@@ -117,17 +118,12 @@ abstract class ApiTestCase extends WebTestCase
         }
     }
 
-    /**
-     * @after
-     */
     protected function purgeDatabase()
     {
-        if (isset($_SERVER['IS_DOCTRINE_ORM_SUPPORTED']) && $_SERVER['IS_DOCTRINE_ORM_SUPPORTED']) {
-            $purger = new ORMPurger($this->entityManager);
-            $purger->purge();
+        $purger = new ORMPurger($this->entityManager);
+        $purger->purge();
 
-            $this->entityManager->clear();
-        }
+        $this->entityManager->clear();
     }
 
     /**


### PR DESCRIPTION
We should purge database before, not after each scenario. Do you have any idea how can we force user to define fixtures loading after database purging? I am afraid that my solution can cause bugs.