### PR TITLE
Update php-matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ In order to run our PHPUnit tests suite, execute following commands:
 $ composer install
 $ test/app/console doctrine:database:create
 $ test/app/console doctrine:schema:create
-$ bin/phpunit test/
+$ bin/phpunit
 ```
 
 Bug Tracking and Suggestions

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "php": ">=5.5.9",
 
-        "coduo/php-matcher": "^2.1@dev",
+        "coduo/php-matcher": "^2.0.0-alpha1",
         "phpspec/php-diff": "^1.0",
         "phpunit/phpunit": "^4.8",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",


### PR DESCRIPTION
Since PHP-Matcher published its [release cycle](https://github.com/coduo/php-matcher/issues/66) we can check if it breaks any thing in our tests. 