### PR TITLE
Access of the functions and fixtures load

### DIFF
--- a/src/ApiTestCase.php
+++ b/src/ApiTestCase.php
@@ -112,6 +112,9 @@ abstract class ApiTestCase extends WebTestCase
         parent::tearDown();
     }
 
+    /**
+     * @return string
+     */
     protected static function getKernelClass()
     {
         if (isset($_SERVER['KERNEL_CLASS'])) {
@@ -264,7 +267,7 @@ abstract class ApiTestCase extends WebTestCase
         $this->assertSourceExists($source);
 
         $finder = new Finder();
-        $finder->files()->name('*.yml')->in($source);
+        $finder->files()->name('*.yml')->in($source)->sortByName();
 
         if (0 === $finder->count()) {
             throw new \RuntimeException(sprintf('There is no files to load in folder %s', $source));
@@ -307,7 +310,7 @@ abstract class ApiTestCase extends WebTestCase
      *
      * @return string
      */
-    private function getFixtureRealPath($source)
+    protected function getFixtureRealPath($source)
     {
         $baseDirectory = $this->getFixturesFolder();
 
@@ -317,7 +320,7 @@ abstract class ApiTestCase extends WebTestCase
     /**
      * @param array $objects
      */
-    private function persistObjects(array $objects)
+    protected function persistObjects(array $objects)
     {
         foreach ($objects as $object) {
             $this->entityManager->persist($object);
@@ -327,7 +330,7 @@ abstract class ApiTestCase extends WebTestCase
     /**
      * @return string
      */
-    private function getFixturesFolder()
+    protected function getFixturesFolder()
     {
         if (null === $this->dataFixturesPath) {
             $this->dataFixturesPath = (isset($_SERVER['FIXTURES_DIR'])) ? $this->getRootDir().$_SERVER['FIXTURES_DIR'] : $this->getCalledClassFolder().'/../DataFixtures/ORM';
@@ -339,7 +342,7 @@ abstract class ApiTestCase extends WebTestCase
     /**
      * @return string
      */
-    private function getExpectedResponsesFolder()
+    protected function getExpectedResponsesFolder()
     {
         if (null === $this->expectedResponsesPath) {
             $this->expectedResponsesPath = (isset($_SERVER['EXPECTED_RESPONSE_DIR'])) ? $this->getRootDir().$_SERVER['EXPECTED_RESPONSE_DIR'] : $this->getCalledClassFolder().'/../Responses/Expected';
@@ -351,7 +354,7 @@ abstract class ApiTestCase extends WebTestCase
     /**
      * @return string
      */
-    private function getMockedResponsesFolder()
+    protected function getMockedResponsesFolder()
     {
         if (null === $this->mockedResponsesPath) {
             $this->mockedResponsesPath = (isset($_SERVER['MOCKED_RESPONSE_DIR'])) ? $this->getRootDir().$_SERVER['MOCKED_RESPONSE_DIR'] : $this->getCalledClassFolder().'/../Responses/Mocked';
@@ -363,7 +366,7 @@ abstract class ApiTestCase extends WebTestCase
     /**
      * @return string
      */
-    private function getCalledClassFolder()
+    protected function getCalledClassFolder()
     {
         $calledClass = get_called_class();
         $calledClassFolder = dirname((new \ReflectionClass($calledClass))->getFileName());
@@ -375,8 +378,10 @@ abstract class ApiTestCase extends WebTestCase
 
     /**
      * @param string $source
+     *
+     * @throws \RuntimeException
      */
-    private function assertSourceExists($source)
+    protected function assertSourceExists($source)
     {
         if (!file_exists($source)) {
             throw new \RuntimeException(sprintf('File %s does not exist', $source));
@@ -386,7 +391,7 @@ abstract class ApiTestCase extends WebTestCase
     /**
      * @return string
      */
-    private function getRootDir()
+    protected function getRootDir()
     {
         return $this->get('kernel')->getRootDir();
     }

--- a/src/JsonApiTestCase.php
+++ b/src/JsonApiTestCase.php
@@ -54,7 +54,7 @@ abstract class JsonApiTestCase extends ApiTestCase
     /**
      * @param Response $response
      */
-    private function assertJsonHeader(Response $response)
+    protected function assertJsonHeader(Response $response)
     {
         parent::assertHeader($response, MediaTypes::JSON);
     }
@@ -67,7 +67,7 @@ abstract class JsonApiTestCase extends ApiTestCase
      *
      * @throws \Exception
      */
-    private function assertJsonResponseContent(Response $response, $filename)
+    protected function assertJsonResponseContent(Response $response, $filename)
     {
         parent::assertResponseContent($this->prettifyJson($response->getContent()), $filename, 'json');
     }
@@ -77,7 +77,7 @@ abstract class JsonApiTestCase extends ApiTestCase
      *
      * @return string
      */
-    private function prettifyJson($content)
+    protected function prettifyJson($content)
     {
         return json_encode(json_decode($content), JSON_PRETTY_PRINT);
     }

--- a/src/XmlApiTestCase.php
+++ b/src/XmlApiTestCase.php
@@ -50,7 +50,7 @@ abstract class XmlApiTestCase extends ApiTestCase
     /**
      * @param Response $response
      */
-    private function assertXmlHeader(Response $response)
+    protected function assertXmlHeader(Response $response)
     {
         parent::assertHeader($response, MediaTypes::XML);
     }
@@ -61,7 +61,7 @@ abstract class XmlApiTestCase extends ApiTestCase
      *
      * @throws \Exception
      */
-    private function assertXmlResponseContent(Response $actualResponse, $filename)
+    protected function assertXmlResponseContent(Response $actualResponse, $filename)
     {
         parent::assertResponseContent($this->prettifyXml($actualResponse->getContent()), $filename, 'xml');
     }
@@ -71,7 +71,7 @@ abstract class XmlApiTestCase extends ApiTestCase
      *
      * @return string
      */
-    private function prettifyXml($actualResponse)
+    protected function prettifyXml($actualResponse)
     {
         $domXmlDocument = new \DOMDocument('1.0');
         $domXmlDocument->preserveWhiteSpace = false;


### PR DESCRIPTION
You should use protected functions instead of using private methods. I have made some modifications on the base of your ApiTestCase, but I can't reuse private methods.

Also I have made quick fix for fixtures. Sometimes I have timestamps in the wrong order (especially after updating fixtures), so they won't be loaded in the right order during the tests. Solution here was to order them by name and load in that order.