### PR TITLE
limit matchers to only those required (json/xml)

### DIFF
--- a/src/ApiTestCase.php
+++ b/src/ApiTestCase.php
@@ -11,7 +11,7 @@
 
 namespace Lakion\ApiTestCase;
 
-use Coduo\PHPMatcher\Factory\SimpleFactory;
+use Coduo\PHPMatcher\Matcher;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Doctrine\ORM\EntityManager;
 use Nelmio\Alice\Fixtures;
@@ -111,6 +111,11 @@ abstract class ApiTestCase extends WebTestCase
     }
 
     /**
+     * @return Matcher
+     */
+    abstract protected function buildMatcher();
+
+    /**
      * return ProcessorInterface[]
      */
     protected function getFixtureProcessors()
@@ -195,7 +200,7 @@ abstract class ApiTestCase extends WebTestCase
         $actualResponse = trim($actualResponse);
         $expectedResponse = trim(file_get_contents(PathBuilder::build($responseSource, sprintf('%s.%s', $filename, $mimeType))));
 
-        $matcher = (new SimpleFactory())->createMatcher();
+        $matcher = $this->buildMatcher();
         $result = $matcher->match($actualResponse, $expectedResponse);
 
         if (!$result) {

--- a/src/JsonApiTestCase.php
+++ b/src/JsonApiTestCase.php
@@ -30,6 +30,14 @@ abstract class JsonApiTestCase extends ApiTestCase
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function buildMatcher()
+    {
+        return MatcherFactory::buildJsonMatcher();
+    }
+
+    /**
      * Asserts that response has JSON content.
      * If filename is set, asserts that response content matches the one in given file.
      * If statusCode is set, asserts that response has given status code.

--- a/src/MatcherFactory.php
+++ b/src/MatcherFactory.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of the ApiTestCase package.
+ *
+ * (c) Lakion
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Lakion\ApiTestCase;
+
+use Coduo\PHPMatcher\Factory;
+use Coduo\PHPMatcher\Lexer;
+use Coduo\PHPMatcher\Matcher;
+use Coduo\PHPMatcher\Parser;
+
+class MatcherFactory
+{
+    /**
+     * @return Matcher
+     */
+    public static function buildXmlMatcher()
+    {
+        return self::buildMatcher(Matcher\XmlMatcher::class);
+    }
+
+    /**
+     * @return Matcher
+     */
+    public static function buildJsonMatcher()
+    {
+        return self::buildMatcher(Matcher\JsonMatcher::class);
+    }
+
+    /**
+     * @param string $matcherClass
+     *
+     * @return Matcher
+     */
+    protected static function buildMatcher($matcherClass)
+    {
+        $orMatcher = self::buildOrMatcher();
+        $chainMatcher = new Matcher\ChainMatcher(array(
+            new $matcherClass($orMatcher),
+        ));
+
+        return new Matcher($chainMatcher);
+    }
+
+    /**
+     * @return Matcher\ChainMatcher
+     */
+    protected static function buildOrMatcher()
+    {
+        $scalarMatchers = self::buildScalarMatchers();
+        $orMatcher = new Matcher\OrMatcher($scalarMatchers);
+        $arrayMatcher = new Matcher\ArrayMatcher(
+            new Matcher\ChainMatcher(array(
+                $orMatcher,
+                $scalarMatchers
+            )),
+            self::buildParser()
+        );
+
+        $chainMatcher = new Matcher\ChainMatcher(array(
+            $orMatcher,
+            $arrayMatcher,
+        ));
+
+        return $chainMatcher;
+    }
+
+    /**
+     * @return Matcher\ChainMatcher
+     */
+    protected static function buildScalarMatchers()
+    {
+        $parser = self::buildParser();
+
+        return new Matcher\ChainMatcher(array(
+            new Matcher\CallbackMatcher(),
+            new Matcher\ExpressionMatcher(),
+            new Matcher\NullMatcher(),
+            new Matcher\StringMatcher($parser),
+            new Matcher\IntegerMatcher($parser),
+            new Matcher\BooleanMatcher(),
+            new Matcher\DoubleMatcher($parser),
+            new Matcher\NumberMatcher(),
+            new Matcher\ScalarMatcher(),
+            new Matcher\WildcardMatcher()
+        ));
+    }
+
+    /**
+     * @return Parser
+     */
+    protected static function buildParser()
+    {
+        return new Parser(new Lexer(), new Parser\ExpanderInitializer());
+    }
+}

--- a/src/XmlApiTestCase.php
+++ b/src/XmlApiTestCase.php
@@ -30,6 +30,14 @@ abstract class XmlApiTestCase extends ApiTestCase
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function buildMatcher()
+    {
+        return MatcherFactory::buildXmlMatcher();
+    }
+
+    /**
      * @param Response $response
      * @param string $filename
      * @param int $statusCode


### PR DESCRIPTION
this avoid potentially confusing results if the expected/actual result is not
valid JSON (as the matcher library tries to sniff the type of content being
matched)