### PR TITLE
[RFC] Introduce a PathBuilder helper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ cache:
 php:
   - 7.0
   - 5.6
-  - 5.5
 
 env:
   matrix:

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "php": "^5.5.9|^7.0",
+        "php": "^5.6|^7.0",
 
         "coduo/php-matcher": "^2.0",
         "doctrine/data-fixtures": "~1.1.0",

--- a/src/ApiTestCase.php
+++ b/src/ApiTestCase.php
@@ -191,13 +191,7 @@ abstract class ApiTestCase extends WebTestCase
     {
         $responseSource = $this->getExpectedResponsesFolder();
 
-        $expectedResponse = file_get_contents(sprintf(
-            '%s%s%s.%s',
-            $responseSource,
-            DIRECTORY_SEPARATOR,
-            $filename,
-            $mimeType
-        ));
+        $expectedResponse = file_get_contents(PathBuilder::build($responseSource, sprintf('%s.%s', $filename, $mimeType)));
 
         $factory = new SimpleFactory();
         $matcher = $factory->createMatcher();
@@ -228,7 +222,7 @@ abstract class ApiTestCase extends WebTestCase
         if (!$response->isSuccessful()) {
             $openCommand = isset($_SERVER['OPEN_BROWSER_COMMAND']) ? $_SERVER['OPEN_BROWSER_COMMAND'] : 'open %s';
 
-            $filename = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . uniqid() . '.html';
+            $filename = PathBuilder::build(rtrim(sys_get_temp_dir(), \DIRECTORY_SEPARATOR), uniqid() . '.html');
             file_put_contents($filename, $response->getContent());
             system(sprintf($openCommand, escapeshellarg($filename)));
 
@@ -249,12 +243,7 @@ abstract class ApiTestCase extends WebTestCase
     {
         $responseSource = $this->getMockedResponsesFolder();
 
-        return json_decode(file_get_contents(sprintf(
-            '%s%s%s.json',
-            $responseSource,
-            DIRECTORY_SEPARATOR,
-            $filename
-        )), true);
+        return json_decode(file_get_contents(PathBuilder::build($responseSource, $filename . '.json')), true);
     }
 
     /**
@@ -328,7 +317,7 @@ abstract class ApiTestCase extends WebTestCase
     {
         $baseDirectory = $this->getFixturesFolder();
 
-        return $baseDirectory . DIRECTORY_SEPARATOR . $source;
+        return PathBuilder::build($baseDirectory, $source);
     }
 
     /**
@@ -337,7 +326,9 @@ abstract class ApiTestCase extends WebTestCase
     private function getFixturesFolder()
     {
         if (null === $this->dataFixturesPath) {
-            $this->dataFixturesPath = isset($_SERVER['FIXTURES_DIR']) ? $this->getRootDir() . $_SERVER['FIXTURES_DIR'] : $this->getCalledClassFolder() . '/../DataFixtures/ORM';
+            $this->dataFixturesPath = isset($_SERVER['FIXTURES_DIR']) ?
+                PathBuilder::build($this->getRootDir(), $_SERVER['FIXTURES_DIR'] ) :
+                PathBuilder::build($this->getCalledClassFolder(), '..', 'DataFixtures', 'ORM');
         }
 
         return $this->dataFixturesPath;
@@ -349,7 +340,9 @@ abstract class ApiTestCase extends WebTestCase
     private function getExpectedResponsesFolder()
     {
         if (null === $this->expectedResponsesPath) {
-            $this->expectedResponsesPath = isset($_SERVER['EXPECTED_RESPONSE_DIR']) ? $this->getRootDir() . $_SERVER['EXPECTED_RESPONSE_DIR'] : $this->getCalledClassFolder() . '/../Responses/Expected';
+            $this->expectedResponsesPath = isset($_SERVER['EXPECTED_RESPONSE_DIR']) ?
+                PathBuilder::build($this->getRootDir(), $_SERVER['EXPECTED_RESPONSE_DIR']) :
+                PathBuilder::build($this->getCalledClassFolder(), '..', 'Responses', 'Expected');
         }
 
         return $this->expectedResponsesPath;
@@ -361,7 +354,9 @@ abstract class ApiTestCase extends WebTestCase
     private function getMockedResponsesFolder()
     {
         if (null === $this->mockedResponsesPath) {
-            $this->mockedResponsesPath = isset($_SERVER['MOCKED_RESPONSE_DIR']) ? $this->getRootDir() . $_SERVER['MOCKED_RESPONSE_DIR'] : $this->getCalledClassFolder() . '/../Responses/Mocked';
+            $this->mockedResponsesPath = isset($_SERVER['MOCKED_RESPONSE_DIR']) ?
+                PathBuilder::build($this->getRootDir(), $_SERVER['MOCKED_RESPONSE_DIR']) :
+                PathBuilder::build($this->getCalledClassFolder(), '..', 'Responses', 'Mocked');
         }
 
         return $this->mockedResponsesPath;

--- a/src/PathBuilder.php
+++ b/src/PathBuilder.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the ApiTestCase package.
+ *
+ * (c) Lakion
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Lakion\ApiTestCase;
+
+/**
+ * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
+ */
+class PathBuilder
+{
+    /**
+     * @param array ...$segments unlimited number of path segments
+     *
+     * @return string
+     */
+    public static function build(...$segments)
+    {
+        return implode(DIRECTORY_SEPARATOR, $segments);
+    }
+}

--- a/src/PathBuilder.php
+++ b/src/PathBuilder.php
@@ -14,8 +14,15 @@ namespace Lakion\ApiTestCase;
 /**
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
  */
-class PathBuilder
+final class PathBuilder
 {
+    /**
+     * Hacky way to create a 'static' php class
+     */
+    private function __construct()
+    {
+    }
+
     /**
      * @param array ...$segments unlimited number of path segments
      *


### PR DESCRIPTION
During #67 I found it really annoying to carry about `DIRECTORY_SEPARATOR`, so I decide to do something about it. But with this implementation, a php version bump to 5.6 is require, thats why I have  add a RFC flag. Please, share your thoughts, should it be added or not. 