### PR TITLE
Missing use statement

### DIFF
--- a/src/ApiTestCase.php
+++ b/src/ApiTestCase.php
@@ -21,6 +21,7 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\DependencyInjection\ResettableContainerInterface;
 
 /**
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | 
| License         | MIT

In the #79 the check [compares to the instance of ResettableContainerInterface](https://github.com/Lakion/ApiTestCase/pull/79/files#diff-dea7b692b63f5bbb853eaa6c6fd1cedeR85) but we have missed an use statement