### PR TITLE
boot clients without debug

### DIFF
--- a/src/ApiTestCase.php
+++ b/src/ApiTestCase.php
@@ -71,7 +71,7 @@ abstract class ApiTestCase extends WebTestCase
      */
     public static function createSharedKernel()
     {
-        static::$sharedKernel = static::createKernel();
+        static::$sharedKernel = static::createKernel(['debug' => false]);
         static::$sharedKernel->boot();
     }
 
@@ -94,7 +94,7 @@ abstract class ApiTestCase extends WebTestCase
      */
     public function setUpClient()
     {
-        $this->client = static::createClient();
+        $this->client = static::createClient(['debug' => false]);
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets | 
| License         | MIT

Is there any need for these to have debug enabled?
Again, this lowers my test suite from
3.5 minutes and 100MB to
3.1 minutes and 50MB

