### PR TITLE
Customize TMP_DIR

### DIFF
--- a/src/ApiTestCase.php
+++ b/src/ApiTestCase.php
@@ -236,8 +236,9 @@ abstract class ApiTestCase extends WebTestCase
     {
         if (!$response->isSuccessful()) {
             $openCommand = isset($_SERVER['OPEN_BROWSER_COMMAND']) ? $_SERVER['OPEN_BROWSER_COMMAND'] : 'open %s';
-
-            $filename = PathBuilder::build(rtrim(sys_get_temp_dir(), \DIRECTORY_SEPARATOR), uniqid() . '.html');
+            $tmpDir = isset($_SERVER['TMP_DIR']) ? $_SERVER['TMP_DIR'] : sys_get_temp_dir();
+            
+            $filename = PathBuilder::build(rtrim($tmpDir, \DIRECTORY_SEPARATOR), uniqid() . '.html');
             file_put_contents($filename, $response->getContent());
             system(sprintf($openCommand, escapeshellarg($filename)));
 


### PR DESCRIPTION
sys_get_temp_dir() function does not account for virtualhost-specific modifications to the temp path. It is difficult to obtain error reports from the docker or other VM to host machine.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets |--
| License         | MIT
