### PR TITLE
Support for PHPUnit 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,9 @@ cache:
 php:
     - 7.1
     - 7.0
-    - hhvm
 
 matrix:
     fast_finish: true
-    allow_failures:
-        - php: hhvm
 
 before_install:
     - phpenv config-rm xdebug.ini || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ cache:
 php:
     - 7.1
     - 7.0
-    - 5.6
     - hhvm
 
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "php": "^5.6|^7.0",
+        "php": "^7.0",
 
         "coduo/php-matcher": "^2.1",
         "doctrine/data-fixtures": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "doctrine/orm": "^2.5",
         "nelmio/alice": "^2.2",
         "phpspec/php-diff": "^1.1",
-        "phpunit/phpunit": "^5.7",
+        "phpunit/phpunit": "^6.0",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",
         "symfony/browser-kit": "^3.2",
         "symfony/finder": "^3.2",

--- a/test/src/Tests/Controller/SampleControllerJsonTest.php
+++ b/test/src/Tests/Controller/SampleControllerJsonTest.php
@@ -12,7 +12,7 @@
 namespace Lakion\ApiTestCase\Test\Tests\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
-use PHPUnit_Framework_AssertionFailedError;
+use PHPUnit\Framework\AssertionFailedError;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -30,7 +30,7 @@ class SampleControllerJsonTest extends JsonApiTestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_AssertionFailedError
+     * @expectedException \PHPUnit\Framework\AssertionFailedError
      */
     public function testGetHelloWorldIncorrectResponse()
     {

--- a/test/src/Tests/Controller/SampleControllerXmlTest.php
+++ b/test/src/Tests/Controller/SampleControllerXmlTest.php
@@ -12,7 +12,6 @@
 namespace Lakion\ApiTestCase\Test\Tests\Controller;
 
 use Lakion\ApiTestCase\XmlApiTestCase;
-use PHPUnit_Framework_AssertionFailedError;
 
 /**
  * @author Arkadiusz Krakowiak <arkadiusz.krakowiak@lakion.com>
@@ -29,7 +28,7 @@ class SampleControllerXmlTest extends XmlApiTestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_AssertionFailedError
+     * @expectedException \PHPUnit\Framework\AssertionFailedError
      */
     public function testGetHelloWorldIncorrectResponse()
     {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes?
| BC breaks?      | yes
| Related tickets | #86 
| License         | MIT

This changes the library to work only with PHPUnit 6. Support for older versions is dropped, as suggested by @michalmarcinkowski on [Twitter](https://twitter.com/micmarcinkowski/status/872402441383424000).

Note that PHPUnit 6 requires PHP 7.0+.