### PR TITLE
Use unescaped unicode in JSON for improved diff

### DIFF
--- a/src/JsonApiTestCase.php
+++ b/src/JsonApiTestCase.php
@@ -87,6 +87,6 @@ abstract class JsonApiTestCase extends ApiTestCase
      */
     private function prettifyJson($content)
     {
-        return json_encode(json_decode($content), JSON_PRETTY_PRINT);
+        return json_encode(json_decode($content), JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
     }
 }

--- a/test/src/Controller/SampleController.php
+++ b/test/src/Controller/SampleController.php
@@ -37,7 +37,11 @@ class SampleController extends Controller
         $acceptFormat = $request->headers->get('Accept');
 
         if ('application/json' === $acceptFormat) {
-            return new JsonResponse(['message' => 'Hello ApiTestCase World!']);
+            return new JsonResponse([
+                'message' => 'Hello ApiTestCase World!',
+                'unicode' => '€ ¥ 💰',
+                'path' => '/p/a/t/h'
+            ]);
         }
 
         $content = '<?xml version="1.0" encoding="UTF-8"?><greetings>Hello world!</greetings>';

--- a/test/src/Tests/Controller/SampleControllerJsonTest.php
+++ b/test/src/Tests/Controller/SampleControllerJsonTest.php
@@ -12,7 +12,6 @@
 namespace Lakion\ApiTestCase\Test\Tests\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
-use PHPUnit\Framework\AssertionFailedError;
 use Symfony\Component\HttpFoundation\Response;
 
 /**

--- a/test/src/Tests/Responses/Expected/hello_matcher_world.json
+++ b/test/src/Tests/Responses/Expected/hello_matcher_world.json
@@ -1,3 +1,5 @@
 {
-    "message": @string@
+    "message": @string@,
+    "unicode": @string@,
+    "path": @string@
 }

--- a/test/src/Tests/Responses/Expected/hello_wild_card.json
+++ b/test/src/Tests/Responses/Expected/hello_wild_card.json
@@ -1,3 +1,5 @@
 {
-    "message": @wildcard@
+    "message": @wildcard@,
+    "unicode": @wildcard@,
+    "path": @wildcard@
 }

--- a/test/src/Tests/Responses/Expected/hello_world.json
+++ b/test/src/Tests/Responses/Expected/hello_world.json
@@ -1,3 +1,5 @@
 {
-    "message": "Hello ApiTestCase World!"
+    "message": "Hello ApiTestCase World!",
+    "unicode": "€ ¥ 💰",
+    "path": "/p/a/t/h"
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no (tested with local Sylius tests)
| Related tickets | -
| License         | MIT

Since PHP 5.4 we're able to use these new JSON constants:
- https://secure.php.net/manual/en/json.constants.php#constant.json-unescaped-slashes
- https://secure.php.net/manual/en/json.constants.php#constant.json-unescaped-unicode

## Without the change
```
There is no element under path [unicode] in pattern.
@@ -1,3 +1,5 @@
 {
-    "message": @string@
+    "message": "Hello ApiTestCase World!",
+    "unicode": "\u20ac \u00a5 \ud83d\udcb0",
+    "path": "\/p\/a\/t\/h"
 }
```

## With the change
```
There is no element under path [unicode] in pattern.
@@ -1,3 +1,5 @@
 {
-    "message": @string@
+    "message": "Hello ApiTestCase World!",
+    "unicode": "€ ¥ 💰",
+    "path": "/p/a/t/h"
 }
```

Let me know what you think