### PR TITLE
Upgraded Alice to version 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ cache:
 
 php:
     - 7.1
-    - 7.0
 
 matrix:
     fast_finish: true

--- a/README.md
+++ b/README.md
@@ -203,7 +203,40 @@ From this moment, first `getInventory` method call will return the response defi
 ApiTestCase is integrated with ``nelmio/alice``. Thanks to this nice library you can easily load your fixtures when you need them. You have to define your fixtures and place them in an appropriate directory.
 Here is some example how to define your fixtures and use case. For more information how to define your fixtures check [Alice's documentation](https://github.com/nelmio/alice). 
 
-Let's say you have a mapped Doctrine entity called Book in your application: 
+In order to use Alice with Doctrine, you should enable two additional bundles:
+
+**Symfony 4.0+**
+
+```php
+// config/bundles.php
+return [
+    // ...
+    
+    Nelmio\Alice\Bridge\Symfony\NelmioAliceBundle::class => ['test' => true],
+    Fidry\AliceDataFixtures\Bridge\Symfony\FidryAliceDataFixturesBundle::class => ['test' => true],
+];
+```
+
+**Symfony 3**
+
+```php
+// app/AppKernel.php
+class AppKernel extends Kernel
+{
+    public function registerBundles()
+    {
+        // ...
+
+        if ('test' === $this->getEnvironment()) {
+            new Nelmio\Alice\Bridge\Symfony\NelmioAliceBundle(),
+            new Fidry\AliceDataFixtures\Bridge\Symfony\FidryAliceDataFixturesBundle(),
+        }
+    }
+}
+
+```
+
+Now, let's say you have a mapped Doctrine entity called Book in your application: 
 
 ```php
     class Book 

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",
         "symfony/browser-kit": "^3.2",
         "symfony/finder": "^3.2",
-        "symfony/framework-bundle": "^3.2"
+        "symfony/framework-bundle": "^3.2",
+        "theofidry/alice-data-fixtures": "^1.0@RC"
     },
     "require-dev": {
         "symfony/serializer": "^3.2"
@@ -58,5 +59,6 @@
         "branch-alias": {
             "dev-master": "2.0-dev"
         }
-    }
+    },
+    "minimum-stability": "beta"
 }

--- a/composer.json
+++ b/composer.json
@@ -60,5 +60,5 @@
             "dev-master": "2.0-dev"
         }
     },
-    "minimum-stability": "beta"
+    "minimum-stability": "rc"
 }

--- a/composer.json
+++ b/composer.json
@@ -60,5 +60,5 @@
             "dev-master": "2.0-dev"
         }
     },
-    "minimum-stability": "rc"
+    "minimum-stability": "RC"
 }

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "doctrine/data-fixtures": "^1.2",
         "doctrine/doctrine-bundle": "^1.6",
         "doctrine/orm": "^2.5",
-        "nelmio/alice": "^2.2",
+        "nelmio/alice": "^3.1",
         "phpspec/php-diff": "^1.1",
         "phpunit/phpunit": "^6.0",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": "^7.1",
 
         "coduo/php-matcher": "^2.1",
         "doctrine/data-fixtures": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "symfony/browser-kit": "^3.2",
         "symfony/finder": "^3.2",
         "symfony/framework-bundle": "^3.2",
-        "theofidry/alice-data-fixtures": "^1.0@RC"
+        "theofidry/alice-data-fixtures": "^1.0"
     },
     "require-dev": {
         "symfony/serializer": "^3.2"
@@ -59,6 +59,5 @@
         "branch-alias": {
             "dev-master": "2.0-dev"
         }
-    },
-    "minimum-stability": "RC"
+    }
 }

--- a/src/ApiTestCase.php
+++ b/src/ApiTestCase.php
@@ -14,8 +14,7 @@ namespace Lakion\ApiTestCase;
 use Coduo\PHPMatcher\Matcher;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Doctrine\ORM\EntityManager;
-use Nelmio\Alice\Fixtures;
-use Nelmio\Alice\Persister\Doctrine;
+use Fidry\AliceDataFixtures\LoaderInterface;
 use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\Finder\Finder;
@@ -57,7 +56,7 @@ abstract class ApiTestCase extends WebTestCase
     protected $dataFixturesPath;
 
     /**
-     * @var Fixtures
+     * @var LoaderInterface
      */
     private $fixtureLoader;
 
@@ -106,7 +105,8 @@ abstract class ApiTestCase extends WebTestCase
             $this->entityManager = static::$sharedKernel->getContainer()->get('doctrine.orm.entity_manager');
             $this->entityManager->getConnection()->connect();
 
-            $this->fixtureLoader = new Fixtures(new Doctrine($this->getEntityManager()), [], $this->getFixtureProcessors());
+            $this->fixtureLoader = static::$sharedKernel->getContainer()->get('fidry_alice_data_fixtures.loader.doctrine');
+
             $this->purgeDatabase();
         }
     }
@@ -284,7 +284,7 @@ abstract class ApiTestCase extends WebTestCase
             $files[] = $file->getRealPath();
         }
 
-        return $this->getFixtureLoader()->loadFiles($files);
+        return $this->getFixtureLoader()->load($files);
     }
 
     /**
@@ -297,11 +297,11 @@ abstract class ApiTestCase extends WebTestCase
         $source = $this->getFixtureRealPath($source);
         $this->assertSourceExists($source);
 
-        return $this->getFixtureLoader()->loadFiles($source);
+        return $this->getFixtureLoader()->load([$source]);
     }
 
     /**
-     * @return Fixtures
+     * @return LoaderInterface
      */
     protected function getFixtureLoader()
     {

--- a/test/app/AppKernel.php
+++ b/test/app/AppKernel.php
@@ -26,6 +26,8 @@ class AppKernel extends Kernel
         return array(
             new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
+            new Nelmio\Alice\Bridge\Symfony\NelmioAliceBundle(),
+            new Fidry\AliceDataFixtures\Bridge\Symfony\FidryAliceDataFixturesBundle(),
         );
     }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no?
| BC breaks?      | yes
| Related tickets | #99
| License         | MIT

I made some changes in order to make the library work with Alice 3. I'm not sure if there's a better way to achieve this, so I would like to hear what you'd say.

The persistence layer is removed from Alice 3, so an additional library is required. The simplest way to bring the Doctrine support back was to require two additional bundles:
* Nelmio\Alice\Bridge\Symfony\NelmioAliceBundle
* Fidry\AliceDataFixtures\Bridge\Symfony\FidryAliceDataFixturesBundle

(The second bundle doesn't have a stable release yet, so if we go with this approach we'd have to wait for a bit.)

Upgrading to Alice 3 will probably break some fixtures in existing projects.

Because of this breaks, the major version of this library should be bumped.

PS. This will also require to change the minimal required PHP version to 7.1