### PR TITLE
Allow to install coduo/php-matcher ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "php": "^7.1",
 
-        "coduo/php-matcher": "^2.1",
+        "coduo/php-matcher": "^2.3|^3.0",
         "doctrine/data-fixtures": "^1.2",
         "doctrine/doctrine-bundle": "^1.6",
         "doctrine/orm": "^2.5",


### PR DESCRIPTION
coduo/php-matcher v2.* does not support Symfony 4.