### PR TITLE
Add option to control whether JSON will be matched Unicode escaped or not

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ To customize your test suite configuration you can add a few more options to php
     <server name="OPEN_BROWSER_COMMAND" value="open %s" />
     <server name="IS_DOCTRINE_ORM_SUPPORTED" value="true/false" />
     <server name="TMP_DIR" value="/tmp/path/to/temporary/folder/" />
+    <server name="ESCAPE_JSON" value="true/false" />
 </php>
 ```
 
@@ -299,6 +300,7 @@ To customize your test suite configuration you can add a few more options to php
  * `OPEN_BROWSER_COMMAND` is a command which will be used to open browser with an exception.
  * `IS_DOCTRINE_ORM_SUPPORTED` is a flag which turns on doctrine support includes handy data fixtures loader and database purger.
  * `TMP_DIR` variable contains a path to temporary folder, where the log files will be stored.
+ * `ESCAPE_JSON` is a flag which turns on escaping (unicode characters and slashes) of your JSON output before comparing it to expected data. The default value is false. This flag only exists for backwards compatibility with previous versions of ApiTestCase (when turned on) and will be removed in a future version.
  
 Sample Project
 --------------

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,7 @@
+# ApiTestCase upgrade instructions
+
+## Upgrading from v2 to v3
+
+* JSON output is not escaped any more when comparing it to expected data. Turn on `ESCAPE_JSON` flag in your test configuration retain previous behaviour.
+
+  NOTE: This flag exists for temporary BC between v2 and v3 and will be removed in v4. v4 will not escape JSON output.

--- a/src/JsonApiTestCase.php
+++ b/src/JsonApiTestCase.php
@@ -87,6 +87,11 @@ abstract class JsonApiTestCase extends ApiTestCase
      */
     private function prettifyJson($content)
     {
-        return json_encode(json_decode($content), JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $jsonFlags = JSON_PRETTY_PRINT;
+        if (!isset($_SERVER['ESCAPE_JSON']) || true !== $_SERVER['ESCAPE_JSON']) {
+            $jsonFlags = $jsonFlags | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES;
+        }
+
+        return json_encode(json_decode($content), $jsonFlags);
     }
 }

--- a/test/src/Tests/Controller/SampleControllerJsonTest.php
+++ b/test/src/Tests/Controller/SampleControllerJsonTest.php
@@ -28,6 +28,17 @@ class SampleControllerJsonTest extends JsonApiTestCase
         $this->assertResponse($response, 'hello_world');
     }
 
+    public function testGetHelloWorldResponseWithEscapedUnicode()
+    {
+        $_SERVER['ESCAPE_JSON'] = true;
+
+        $this->client->request('GET', '/');
+
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'hello_world_escaped');
+    }
+
     /**
      * @expectedException \PHPUnit\Framework\AssertionFailedError
      */

--- a/test/src/Tests/Responses/Expected/hello_world_escaped.json
+++ b/test/src/Tests/Responses/Expected/hello_world_escaped.json
@@ -1,0 +1,5 @@
+{
+    "message": "Hello ApiTestCase World!",
+    "unicode": "\u20ac \u00a5 \ud83d\udcb0",
+    "path": "/p/a/t/h"
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no?
| Related tickets | mentioned in #112
| License         | MIT
