### PR TITLE
make methods protected

### DIFF
--- a/src/JsonApiTestCase.php
+++ b/src/JsonApiTestCase.php
@@ -62,7 +62,7 @@ abstract class JsonApiTestCase extends ApiTestCase
     /**
      * @param Response $response
      */
-    private function assertJsonHeader(Response $response)
+    protected function assertJsonHeader(Response $response)
     {
         parent::assertHeader($response, 'application/json');
     }
@@ -75,7 +75,7 @@ abstract class JsonApiTestCase extends ApiTestCase
      *
      * @throws \Exception
      */
-    private function assertJsonResponseContent(Response $response, $filename)
+    protected function assertJsonResponseContent(Response $response, $filename)
     {
         parent::assertResponseContent($this->prettifyJson($response->getContent()), $filename, 'json');
     }
@@ -85,7 +85,7 @@ abstract class JsonApiTestCase extends ApiTestCase
      *
      * @return string
      */
-    private function prettifyJson($content)
+    protected function prettifyJson($content)
     {
         $jsonFlags = JSON_PRETTY_PRINT;
         if (!isset($_SERVER['ESCAPE_JSON']) || true !== $_SERVER['ESCAPE_JSON']) {

--- a/src/XmlApiTestCase.php
+++ b/src/XmlApiTestCase.php
@@ -58,7 +58,7 @@ abstract class XmlApiTestCase extends ApiTestCase
     /**
      * @param Response $response
      */
-    private function assertXmlHeader(Response $response)
+    protected function assertXmlHeader(Response $response)
     {
         parent::assertHeader($response, 'application/xml');
     }
@@ -69,7 +69,7 @@ abstract class XmlApiTestCase extends ApiTestCase
      *
      * @throws \Exception
      */
-    private function assertXmlResponseContent(Response $actualResponse, $filename)
+    protected function assertXmlResponseContent(Response $actualResponse, $filename)
     {
         parent::assertResponseContent($this->prettifyXml($actualResponse->getContent()), $filename, 'xml');
     }
@@ -79,7 +79,7 @@ abstract class XmlApiTestCase extends ApiTestCase
      *
      * @return string
      */
-    private function prettifyXml($actualResponse)
+    protected function prettifyXml($actualResponse)
     {
         $domXmlDocument = new \DOMDocument('1.0');
         $domXmlDocument->preserveWhiteSpace = false;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| BC breaks?      | no
| Related tickets | 
| License         | MIT

Any reason these are private?
My API returns `application/hal+json`, so I wanted to override `assertJsonHeader`.
