### PR TITLE
fix api header content type with charset

### DIFF
--- a/src/ApiTestCase.php
+++ b/src/ApiTestCase.php
@@ -184,8 +184,9 @@ abstract class ApiTestCase extends WebTestCase
      */
     protected function assertHeader(Response $response, $contentType)
     {
-        self::assertTrue(
-            $response->headers->contains('Content-Type', $contentType),
+        self::assertContains(
+            $contentType,
+            $response->headers->get('Content-Type'),
             $response->headers
         );
     }

--- a/test/src/Controller/SampleController.php
+++ b/test/src/Controller/SampleController.php
@@ -21,6 +21,7 @@ use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Encoder\XmlEncoder;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer;
+use Webmozart\Assert\Assert;
 
 /**
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
@@ -36,11 +37,13 @@ class SampleController extends Controller
     {
         $acceptFormat = $request->headers->get('Accept');
 
-        if ('application/json' === $acceptFormat) {
+        if (false !== strpos($acceptFormat, 'application/json')) {
             return new JsonResponse([
                 'message' => 'Hello ApiTestCase World!',
                 'unicode' => '€ ¥ 💰',
                 'path' => '/p/a/t/h'
+            ], 200, [
+                'Content-Type' => $acceptFormat
             ]);
         }
 

--- a/test/src/Tests/Controller/SampleControllerJsonTest.php
+++ b/test/src/Tests/Controller/SampleControllerJsonTest.php
@@ -28,6 +28,15 @@ class SampleControllerJsonTest extends JsonApiTestCase
         $this->assertResponse($response, 'hello_world');
     }
 
+    public function testGetHelloWorldResponseWithCharsetOnContentType()
+    {
+        $this->client->request('GET', '/', [], [], ['HTTP_ACCEPT' => 'application/json; charset=utf-8']);
+
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'hello_world');
+    }
+
     public function testGetHelloWorldResponseWithEscapedUnicode()
     {
         $_SERVER['ESCAPE_JSON'] = true;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets |
| License         | MIT

This fix allows to have a json header with "Content-type: application/json; charset=utf-8".

I need help to create an endpoint with this content-type to add a test case to validate this fix.